### PR TITLE
Implementação de mock de clientes

### DIFF
--- a/domains/clientes/components/CadastroCliente.vue
+++ b/domains/clientes/components/CadastroCliente.vue
@@ -1,10 +1,33 @@
 <template>
   <v-container>
-    <h2>Cadastro de Cliente</h2>
-    <p>Em desenvolvimento...</p>
+    <v-row class="align-center mb-4">
+      <v-btn icon="mdi-arrow-left" variant="plain" @click="$router.push('/clientes')" />
+      <h2 class="ml-2">Cadastro de Cliente</h2>
+    </v-row>
+    <v-form>
+      <v-text-field label="Nome" v-model="form.nome" />
+      <v-text-field label="Sobrenome" v-model="form.sobrenome" />
+      <v-text-field label="CPF" v-model="form.cpf" />
+      <v-text-field label="Telefone" v-model="form.telefone" />
+      <v-text-field label="Endereço" v-model="form.endereco" />
+    </v-form>
   </v-container>
 </template>
 
 <script>
-export default {}
+export default {
+  data() {
+    return {
+      form: { nome: '', sobrenome: '', cpf: '', telefone: '', endereco: '' }
+    }
+  },
+  mounted() {
+    const q = this.$route.query.cliente
+    if (q) {
+      try {
+        this.form = JSON.parse(q)
+      } catch (e) {}
+    }
+  }
+}
 </script>

--- a/domains/clientes/components/CadastroCliente.vue
+++ b/domains/clientes/components/CadastroCliente.vue
@@ -8,7 +8,24 @@
       <v-text-field label="Nome" v-model="form.nome" />
       <v-text-field label="Sobrenome" v-model="form.sobrenome" />
       <v-text-field label="CPF" v-model="form.cpf" />
-      <v-text-field label="Telefone" v-model="form.telefone" />
+
+      <div v-for="(tel, i) in form.telefones" :key="i" class="d-flex mb-2">
+        <v-text-field
+          class="flex-grow-1"
+          label="Telefone"
+          v-model="form.telefones[i]"
+        />
+        <v-btn
+          icon="mdi-delete"
+          variant="plain"
+          @click="removerTelefone(i)"
+          v-if="form.telefones.length > 1"
+        />
+      </div>
+      <v-btn variant="tonal" class="mb-4" @click="adicionarTelefone">
+        Adicionar telefone
+      </v-btn>
+
       <v-text-field label="Endereço" v-model="form.endereco" />
     </v-form>
   </v-container>
@@ -18,15 +35,30 @@
 export default {
   data() {
     return {
-      form: { nome: '', sobrenome: '', cpf: '', telefone: '', endereco: '' }
+      form: { nome: '', sobrenome: '', cpf: '', telefones: [''], endereco: '' }
     }
   },
   mounted() {
     const q = this.$route.query.cliente
     if (q) {
       try {
-        this.form = JSON.parse(q)
+        const dados = JSON.parse(q)
+        if (Array.isArray(dados.telefones)) {
+          this.form = { ...this.form, ...dados }
+        } else if (dados.telefone) {
+          this.form = { ...this.form, ...dados, telefones: [dados.telefone] }
+        } else {
+          this.form = { ...this.form, ...dados }
+        }
       } catch (e) {}
+    }
+  },
+  methods: {
+    adicionarTelefone() {
+      this.form.telefones.push('')
+    },
+    removerTelefone(idx) {
+      if (this.form.telefones.length > 1) this.form.telefones.splice(idx, 1)
     }
   }
 }

--- a/domains/clientes/components/ListaClientes.vue
+++ b/domains/clientes/components/ListaClientes.vue
@@ -1,11 +1,13 @@
 <template>
   <v-container>
-    <v-row class="justify-space-between align-center">
-      <h2>Clientes</h2>
+    <v-row class="align-center mb-4">
+      <v-btn icon="mdi-arrow-left" variant="plain" @click="$router.push('/')" />
+      <h2 class="ml-2">Clientes</h2>
+      <v-spacer></v-spacer>
       <v-btn color="primary" to="/clientes/novo">Adicionar</v-btn>
     </v-row>
     <v-list>
-      <v-list-item v-for="c in clientes" :key="c.id">
+      <v-list-item v-for="c in clientes" :key="c.id" @click="abrir(c)" class="cursor-pointer">
         <v-list-item-title>{{ c.nome }}</v-list-item-title>
       </v-list-item>
     </v-list>
@@ -13,13 +15,18 @@
 </template>
 
 <script>
-import ClienteAPIService from '../services/ClienteAPIService'
+import ClienteMockService from '../services/ClienteMockService'
 export default {
   data() {
     return { clientes: [] }
   },
   async mounted() {
-    this.clientes = await ClienteAPIService.listar()
+    this.clientes = await ClienteMockService.listar()
+  },
+  methods: {
+    abrir(c) {
+      this.$router.push({ path: '/clientes/novo', query: { cliente: JSON.stringify(c) } })
+    }
   }
 }
 </script>

--- a/domains/clientes/components/ListaClientes.vue
+++ b/domains/clientes/components/ListaClientes.vue
@@ -7,8 +7,14 @@
       <v-btn color="primary" to="/clientes/novo">Adicionar</v-btn>
     </v-row>
     <v-list>
-      <v-list-item v-for="c in clientes" :key="c.id" @click="abrir(c)" class="cursor-pointer">
+      <v-list-item
+        v-for="c in clientes"
+        :key="c.id"
+        @click="abrir(c)"
+        class="cursor-pointer"
+      >
         <v-list-item-title>{{ c.nome }}</v-list-item-title>
+        <v-list-item-subtitle>{{ c.telefones ? c.telefones.join(', ') : '' }}</v-list-item-subtitle>
       </v-list-item>
     </v-list>
   </v-container>

--- a/domains/clientes/services/ClienteMockService.js
+++ b/domains/clientes/services/ClienteMockService.js
@@ -6,7 +6,7 @@ export default class ClienteMockService {
         nome: 'João Silva',
         sobrenome: 'Silva',
         cpf: '111.111.111-11',
-        telefone: '(11) 11111-1111',
+        telefones: ['(11) 11111-1111'],
         endereco: 'Rua A, 100'
       },
       {
@@ -14,7 +14,7 @@ export default class ClienteMockService {
         nome: 'Maria Souza',
         sobrenome: 'Souza',
         cpf: '222.222.222-22',
-        telefone: '(22) 22222-2222',
+        telefones: ['(22) 22222-2222', '(22) 99999-9999'],
         endereco: 'Rua B, 200'
       },
       {
@@ -22,7 +22,7 @@ export default class ClienteMockService {
         nome: 'Pedro Santos',
         sobrenome: 'Santos',
         cpf: '333.333.333-33',
-        telefone: '(33) 33333-3333',
+        telefones: ['(33) 33333-3333'],
         endereco: 'Rua C, 300'
       }
     ])

--- a/domains/clientes/services/ClienteMockService.js
+++ b/domains/clientes/services/ClienteMockService.js
@@ -1,0 +1,30 @@
+export default class ClienteMockService {
+  static listar() {
+    return Promise.resolve([
+      {
+        id: 1,
+        nome: 'João Silva',
+        sobrenome: 'Silva',
+        cpf: '111.111.111-11',
+        telefone: '(11) 11111-1111',
+        endereco: 'Rua A, 100'
+      },
+      {
+        id: 2,
+        nome: 'Maria Souza',
+        sobrenome: 'Souza',
+        cpf: '222.222.222-22',
+        telefone: '(22) 22222-2222',
+        endereco: 'Rua B, 200'
+      },
+      {
+        id: 3,
+        nome: 'Pedro Santos',
+        sobrenome: 'Santos',
+        cpf: '333.333.333-33',
+        telefone: '(33) 33333-3333',
+        endereco: 'Rua C, 300'
+      }
+    ])
+  }
+}


### PR DESCRIPTION
## Resumo
- botão de voltar na lista de clientes
- mock para três clientes de exemplo
- tela de cadastro passa a exibir dados do cliente selecionado

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c57ad90348320acbfd4ce5326078c