### PR TITLE
Adicionar tipos em dominios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+package-lock.json
+.DS_Store
+.env

--- a/domains/clientes/Cliente.ts
+++ b/domains/clientes/Cliente.ts
@@ -1,0 +1,94 @@
+export interface ITelefone {
+  numero: string;
+  toString(): string;
+}
+
+export class Telefone implements ITelefone {
+  numero: string;
+
+  constructor(numero: string = '') {
+    const formatted = Telefone.format(numero);
+    if (!formatted) {
+      throw new Error('Telefone invalido');
+    }
+    this.numero = formatted;
+  }
+
+  toString(): string {
+    return this.numero;
+  }
+
+  static format(num: string): string {
+    let v: string = String(num || '').replace(/\D/g, '');
+    if (v.length < 10) return '';
+    v = v.slice(0, 11);
+    v = v.replace(/^(\d{2})(\d)/g, '($1) $2');
+    v = v.replace(/(\d{5})(\d)/, '$1-$2');
+    return v;
+  }
+
+  static formatInput(input: HTMLInputElement): void {
+    input.value = Telefone.format(input.value);
+  }
+}
+
+export interface ICliente {
+  nome: string;
+  sobrenome: string;
+  cpf: string;
+  telefones: Telefone[];
+  endereco: string;
+  readonly nomeCompleto: string;
+  readonly telefonesFormatados: string;
+  readonly telefone: string;
+}
+
+export class Cliente implements ICliente {
+  nome: string;
+  sobrenome: string;
+  cpf: string;
+  telefones: Telefone[];
+  endereco: string;
+
+  constructor(
+    nome: string,
+    sobrenome: string,
+    cpf: string,
+    telefones: Array<string | Telefone> = [],
+    endereco: string
+  ) {
+    this.nome = capitalizar(nome || '').trim();
+    this.sobrenome = capitalizar(sobrenome || '').trim();
+    this.cpf = Cliente.formatCPF(cpf || '');
+    if (!Array.isArray(telefones)) telefones = [telefones];
+    this.telefones = telefones
+      .filter(t => t !== undefined && t !== null && String(t).trim() !== '')
+      .map(t => (t instanceof Telefone ? t : new Telefone(String(t))));
+    this.endereco = capitalizar(endereco || '').trim();
+    if (!this.nome || !this.sobrenome || !this.cpf || !this.endereco) {
+      throw new Error('Todos os campos de cliente são obrigatórios');
+    }
+  }
+
+  static formatCPF(cpf: string): string {
+    let value: string = String(cpf).replace(/\D/g, '');
+    if (value.length > 11) value = value.slice(0, 11);
+    value = value.replace(/(\d{3})(\d)/, '$1.$2');
+    value = value.replace(/(\d{3})(\d)/, '$1.$2');
+    value = value.replace(/(\d{3})(\d{1,2})$/, '$1-$2');
+    return value;
+  }
+
+  get nomeCompleto(): string {
+    return `${this.nome} ${this.sobrenome}`.trim();
+  }
+
+  get telefonesFormatados(): string {
+    return this.telefones.map(t => t.toString()).join(', ');
+  }
+
+  get telefone(): string {
+    return this.telefones[0] ? this.telefones[0].toString() : '';
+  }
+}
+

--- a/domains/clientes/services/ClienteAPIService.ts
+++ b/domains/clientes/services/ClienteAPIService.ts
@@ -1,0 +1,15 @@
+import type { ICliente } from '../Cliente';
+
+export default class ClienteAPIService {
+  static async listar(): Promise<ICliente[]> {
+    try {
+      const resp = await fetch('/api/clientes');
+      if (!resp.ok) return [];
+      return await resp.json();
+    } catch (e) {
+      console.error(e);
+      return [];
+    }
+  }
+}
+

--- a/domains/clientes/services/ClienteMockService.ts
+++ b/domains/clientes/services/ClienteMockService.ts
@@ -1,0 +1,33 @@
+import type { ICliente } from '../Cliente';
+
+export default class ClienteMockService {
+  static listar(): Promise<ICliente[]> {
+    return Promise.resolve([
+      {
+        id: 1,
+        nome: 'Jo\u00e3o Silva',
+        sobrenome: 'Silva',
+        cpf: '111.111.111-11',
+        telefones: ['(11) 11111-1111'],
+        endereco: 'Rua A, 100'
+      },
+      {
+        id: 2,
+        nome: 'Maria Souza',
+        sobrenome: 'Souza',
+        cpf: '222.222.222-22',
+        telefones: ['(22) 22222-2222', '(22) 99999-9999'],
+        endereco: 'Rua B, 200'
+      },
+      {
+        id: 3,
+        nome: 'Pedro Santos',
+        sobrenome: 'Santos',
+        cpf: '333.333.333-33',
+        telefones: ['(33) 33333-3333'],
+        endereco: 'Rua C, 300'
+      }
+    ] as unknown as ICliente[]);
+  }
+}
+

--- a/domains/orcamentos/Orcamento.ts
+++ b/domains/orcamentos/Orcamento.ts
@@ -1,0 +1,60 @@
+import { Cliente } from '../clientes/Cliente';
+
+export interface ItemOrcamento {
+  descricao: string;
+  valor: number;
+}
+
+export interface IOrcamento {
+  cliente: Cliente;
+  itens: ItemOrcamento[];
+  readonly total: number;
+  gerarRecibo(loja?: string): string;
+}
+
+export class Orcamento implements IOrcamento {
+  cliente: Cliente;
+  itens: ItemOrcamento[];
+
+  constructor(cliente: Cliente, itens: ItemOrcamento[] = []) {
+    if (!(cliente instanceof Cliente)) {
+      throw new Error('Cliente inválido');
+    }
+    this.cliente = cliente;
+    this.itens = itens.map(it => ({
+      descricao: capitalizar(it.descricao || ''),
+      valor: Number(it.valor) || 0
+    }));
+  }
+
+  get total(): number {
+    return this.itens.reduce((s, i) => s + i.valor, 0);
+  }
+
+  gerarRecibo(loja: string = 'AMIGOS MÓVEIS PLANEJADOS'): string {
+    const data = new Date().toLocaleDateString('pt-BR');
+    return `╦══════════════════════╥
+        ${loja}
+╚══════════════════════╝
+
+Recibo Eletrônico - Orçamento
+
+Cliente: ${this.cliente.nomeCompleto}
+CPF: ${this.cliente.cpf}
+Telefones: ${this.cliente.telefonesFormatados || ''}
+Endereço: ${this.cliente.endereco}
+
+Itens:
+${this.itens
+      .map(it => `• ${capitalizar(it.descricao).padEnd(22, ' ')}  ${formatarReal(it.valor)}`)
+      .join('\n')}
+
+─────────────────────────
+TOTAL:        ${formatarReal(this.total)}
+─────────────────────────
+
+Data: ${data}
+Agradecemos pela preferência!`;
+  }
+}
+

--- a/domains/termos/Termo.ts
+++ b/domains/termos/Termo.ts
@@ -1,0 +1,15 @@
+export interface ITermo {
+  nome: string;
+  texto: string;
+}
+
+export class Termo implements ITermo {
+  nome: string;
+  texto: string;
+
+  constructor(nome: string, texto: string) {
+    this.nome = capitalizar(nome || '').trim();
+    this.texto = (texto || '').trim();
+  }
+}
+


### PR DESCRIPTION
## Resumo
- criar `.gitignore`
- adicionar definicoes TypeScript para Cliente e Telefone
- adicionar definicoes TypeScript para Orcamento
- adicionar definicoes TypeScript para Termo
- criar servicos de cliente em TypeScript

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c6add6d48832085766341e41ad7d3